### PR TITLE
Update to comply with Pydantic V2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 aiohttp>=3.6
-pydantic>=1.6
+pydantic>=2.5
 requests>=2.24

--- a/yaweather/api.py
+++ b/yaweather/api.py
@@ -121,7 +121,7 @@ class YaWeather(YaWeatherBase):
         :return: ResponseForecast
         """
         result = self._forecast(coordinates, lang, limit, hours, extra)
-        return ResponseForecast.parse_raw(result)
+        return ResponseForecast.model_validate_json(result)
 
     def _informers(self, coordinates: Tuple[float, float], lang: Lang = None) -> bytes:
         request = RequestInformers(
@@ -152,7 +152,7 @@ class YaWeather(YaWeatherBase):
         :return: ResponseInformers
         """
         result = self._informers(coordinates, lang)
-        return ResponseInformers.parse_raw(result)
+        return ResponseInformers.model_validate_json(result)
 
 
 class YaWeatherAsync(YaWeatherBase):
@@ -231,7 +231,7 @@ class YaWeatherAsync(YaWeatherBase):
         :return: ResponseForecast
         """
         result = await self._forecast(coordinates, lang, limit, hours, extra)
-        return ResponseForecast.parse_raw(result)
+        return ResponseForecast.model_validate_json(result)
 
     async def _informers(self, coordinates: Tuple[float, float], lang: Lang = None) -> bytes:
         request = RequestInformers(
@@ -262,4 +262,4 @@ class YaWeatherAsync(YaWeatherBase):
         :return: ResponseInformers
         """
         result = await self._informers(coordinates, lang)
-        return ResponseInformers.parse_raw(result)
+        return ResponseInformers.model_validate_json(result)

--- a/yaweather/models/fact.py
+++ b/yaweather/models/fact.py
@@ -9,7 +9,7 @@ class Fact(Base):
     # What the temperature feels like (°C)
     feels_like: float
     # The water temperature (°C). This parameter is returned for localities where this information is relevant
-    temp_water: Optional[float]
+    temp_water: Optional[float] = None
     # The code of the weather icon.
     icon: str
 
@@ -40,9 +40,9 @@ class Fact(Base):
     # The time when weather data was measured, in Unix time
     obs_time: int
     # Indicates a thunderstorm
-    is_thunder: Optional[bool]
+    is_thunder: Optional[bool] = None
     # Type of precipitation
-    prec_type: Optional[PrecipitationType]
+    prec_type: Optional[PrecipitationType] = None
     # Intensity of precipitation
     # Possible values:
     #    0.00 — No precipitation
@@ -50,7 +50,7 @@ class Fact(Base):
     #    0.50 — Rain or snow
     #    0.75 — Heavy rain or snowfall
     #    1.00 — Heavy downpour or snowstorm
-    prec_strength: Optional[float]
+    prec_strength: Optional[float] = None
     # Cloud cover
     # Possible values:
     #    0.00 — Clear
@@ -58,13 +58,13 @@ class Fact(Base):
     #    0.50 — Cloudy
     #    0.75 — Cloudy
     #    1.00 — Overcast
-    cloudness: Optional[float]
+    cloudness: Optional[float] = None
     # The code for an additional weather event icon
-    phenom_icon: Optional[str]
+    phenom_icon: Optional[str] = None
 
     @property
     def phenom_icon_url(self) -> Optional[str]:
         return self.phenom_icon and f'https://yastatic.net/weather/i/icons/blueye/color/svg/{self.phenom_icon}.svg'
 
     # The code for an additional weather description
-    phenom_condition: Optional[PhenomCondition]
+    phenom_condition: Optional[PhenomCondition] = None

--- a/yaweather/models/forecast.py
+++ b/yaweather/models/forecast.py
@@ -8,34 +8,34 @@ from .base import Base, Condition, DayTime, MoonCode, MoonText, PrecipitationTyp
 
 class ForecastParts(Base):
     # Nighttime forecast
-    night: Optional['Forecast']
+    night: Optional['Forecast'] = None
     # Morning forecast
-    morning: Optional['Forecast']
+    morning: Optional['Forecast'] = None
     # Afternoon forecast
-    day: Optional['Forecast']
+    day: Optional['Forecast'] = None
     # Evening forecast
-    evening: Optional['Forecast']
+    evening: Optional['Forecast'] = None
     # 12-hour forecast for the day
-    day_short: Optional['Forecast']
+    day_short: Optional['Forecast'] = None
     # Nighttime forecast
-    night_short: Optional['Forecast']
+    night_short: Optional['Forecast'] = None
 
 
 class Forecast(Base):
     # Date of the forecast, in the format YYYY-MM-DD
-    date: Optional[datetime.date]
+    date: Optional[datetime.date] = None
     # The date of the forecast in Unix time
-    date_ts: Optional[int]
+    date_ts: Optional[int] = None
     # Week number
-    week: Optional[int]
+    week: Optional[int] = None
     # Time of the sunrise in local time (may be omitted for polar regions)
-    sunrise: Optional[str]
+    sunrise: Optional[str] = None
     # Time of the sunset in local time (may be omitted for polar regions)
-    sunset: Optional[str]
+    sunset: Optional[str] = None
     # Code of the lunar phase.
-    moon_code: Optional[MoonCode]
+    moon_code: Optional[MoonCode] = None
     # Text code for the lunar phase.
-    moon_text: Optional[MoonText]
+    moon_text: Optional[MoonText] = None
     # Forecasts by time of day and 12-hour forecasts.
     # Contains fields that differ by type of forecast:
     #     Nighttime forecast
@@ -47,7 +47,7 @@ class Forecast(Base):
     # All weather forecasts for a certain time of day have the same set of fields
     # All 12-hour forecasts have the same set of fields
     # Note: For the last day returned in the forecast, some of the parts might be missing
-    parts: Optional[ForecastParts]
+    parts: Optional[ForecastParts] = None
 
     @validator('parts', pre=True)
     def parse_parts(cls, v):
@@ -59,46 +59,46 @@ class Forecast(Base):
     # Object with the weather forecast for the night
     # The beginning of the nighttime period corresponds to the beginning of the 24-hour period
     # To specify the upcoming night temperatures, use the object for the nighttime forecast for the next day
-    night: Optional[ForecastParts]
+    night: Optional[ForecastParts] = None
     # Minimum temperature for the time of day (°C)
-    temp_min: Optional[float]
+    temp_min: Optional[float] = None
     # Maximum temperature for the time of day (°C)
-    temp_max: Optional[float]
+    temp_max: Optional[float] = None
     # Average temperature for the time of day (°C)
-    temp_avg: Optional[float]
+    temp_avg: Optional[float] = None
     # What the temperature feels like (°C)
-    feels_like: Optional[float]
+    feels_like: Optional[float] = None
     # The code of the weather icon
-    icon: Optional[str]
+    icon: Optional[str] = None
 
     @property
     def icon_url(self) -> Optional[str]:
         return self.icon and f'https://yastatic.net/weather/i/icons/blueye/color/svg/{self.icon}.svg'
 
     # The code for the weather description
-    condition: Optional[Condition]
+    condition: Optional[Condition] = None
     # Light or dark time of the day
-    daytime: Optional[DayTime]
+    daytime: Optional[DayTime] = None
     # Indicates that the time of day specified in the daytime field is polar
-    polar: Optional[bool]
+    polar: Optional[bool] = None
     # Wind speed (meters per second)
-    wind_speed: Optional[float]
+    wind_speed: Optional[float] = None
     # Speed of wind gusts (meters per second)
-    wind_gust: Optional[float]
+    wind_gust: Optional[float] = None
     # Wind direction
-    wind_dir: Optional[WindDir]
+    wind_dir: Optional[WindDir] = None
     # Atmospheric pressure (mm Hg)
-    pressure_mm: Optional[int]
+    pressure_mm: Optional[int] = None
     # Atmospheric pressure (hPa)
-    pressure_pa: Optional[int]
+    pressure_pa: Optional[int] = None
     # Humidity (percent)
-    humidity: Optional[float]
+    humidity: Optional[float] = None
     # Predicted amount of precipitation (mm)
-    prec_mm: Optional[int]
+    prec_mm: Optional[int] = None
     # Predicted duration of precipitation (minutes)
-    prec_period: Optional[int]
+    prec_period: Optional[int] = None
     # Type of precipitation
-    prec_type: Optional[PrecipitationType]
+    prec_type: Optional[PrecipitationType] = None
     # Intensity of precipitation
     # Possible values:
     #    0.00 — No precipitation
@@ -106,7 +106,7 @@ class Forecast(Base):
     #    0.50 — Rain or snow
     #    0.75 — Heavy rain or snowfall
     #    1.00 — Heavy downpour or snowstorm
-    prec_strength: Optional[float]
+    prec_strength: Optional[float] = None
     # Cloud cover
     # Possible values:
     #    0.00 — Clear
@@ -114,18 +114,18 @@ class Forecast(Base):
     #    0.50 — Cloudy
     #    0.75 — Cloudy
     #    1.00 — Overcast
-    cloudness: Optional[float]
+    cloudness: Optional[float] = None
     # Object with a 12-hour forecast for the day
-    day_short: Optional[ForecastParts]
+    day_short: Optional[ForecastParts] = None
     # Highest daytime or lowest nighttime temperature (°C)
-    temp: Optional[float]
+    temp: Optional[float] = None
     # Object for the hourly forecast
     # Consists of 24 parts (hours) for the first 2-3 days, then an empty string is returned
-    hours: Optional[List['Forecast']]
+    hours: Optional[List['Forecast']] = None
     # The hour the forecast is for (0-23) using the local time
-    hour: Optional[str]
+    hour: Optional[str] = None
     # The time of the forecast in Unix time
-    hour_ts: Optional[float]
+    hour_ts: Optional[float] = None
 
 
 Forecast.update_forward_refs()

--- a/yaweather/models/info.py
+++ b/yaweather/models/info.py
@@ -9,9 +9,9 @@ class TzInfo(Base):
     # Name of the time zone
     name: str
     # Abbreviated name of the time zone
-    abbr: Optional[str]
+    abbr: Optional[str] = None
     # Daylight saving time
-    dst: Optional[bool]
+    dst: Optional[bool] = None
 
 
 class Info(Base):
@@ -20,10 +20,10 @@ class Info(Base):
     # The longitude (in degrees)
     lon: float
     # Information about the time zone
-    tzinfo: Optional[TzInfo]
+    tzinfo: Optional[TzInfo] = None
     # The normal pressure for the given coordinates (mm Hg)
-    def_pressure_mm: Optional[int]
+    def_pressure_mm: Optional[int] = None
     # The normal pressure for the given coordinates (hPa)
-    def_pressure_pa: Optional[int]
+    def_pressure_pa: Optional[int] = None
     # Locality page on Yandex.Weather (https://yandex.ru/pogoda/)
     url: str

--- a/yaweather/models/request.py
+++ b/yaweather/models/request.py
@@ -20,13 +20,13 @@ class RequestForecast(Request):
     # The longitude in degrees
     lon: float
     # The combination of language and country that weather information will be returned for
-    lang: Optional[Lang]
+    lang: Optional[Lang] = None
     # The number of days in the forecast, including the current day
-    limit: Optional[PositiveInt]
+    limit: Optional[PositiveInt] = None
     # For each day, the response will contain the hourly weather forecast
-    hours: Optional[bool]
+    hours: Optional[bool] = None
     # Extra information about precipitation
-    extra: Optional[bool]
+    extra: Optional[bool] = None
 
 
 class RequestInformers(Request):
@@ -35,4 +35,4 @@ class RequestInformers(Request):
     # The longitude in degrees
     lon: float
     # The combination of language and country that weather information will be returned for
-    lang: Optional[Lang]
+    lang: Optional[Lang] = None


### PR DESCRIPTION
Pydantic since version 2 changed its behavior in Optional type fields validation.

Now we are required to set default value for optional fields annotation.

There's a section to read about this logic change:
https://docs.pydantic.dev/latest/migration/#required-optional-and-nullable-fields

Also, the parse_raw() method is deprecated and it's replaced by model_validate_json() method for parsing JSON.