### PR TITLE
pyproject.toml updates

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,6 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "yaweather"
-version = "1.3.0"
 authors = [
     { name = "uburuntu", email = "github@rmbk.me" },
 ]
@@ -31,6 +30,7 @@ dependencies = [
     "pydantic>=2.5",
     "requests>=2.24",
 ]
+dynamic = ["version"]
 
 [project.license]
 text = "MIT"
@@ -56,6 +56,9 @@ platforms = [
     "all",
 ]
 include-package-data = false
+
+[tool.setuptools.dynamic]
+version = {attr = "yaweather.__version__"}
 
 [tool.setuptools.packages.find]
 exclude = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ content-type = "text/markdown"
 Homepage = "https://github.com/uburuntu/yaweather"
 Download = "https://github.com/uburuntu/yaweather/archive/master.zip"
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
     "codecov>=2.0",
     "pytest>=5.4",

--- a/yaweather/__init__.py
+++ b/yaweather/__init__.py
@@ -25,7 +25,7 @@ __author__ = 'uburuntu'
 __email__ = 'github@rmbk.me'
 
 __license__ = 'MIT'
-__version__ = '1.2.2'
+__version__ = '1.3.0'
 
 __all__ = (
     'Base',


### PR DESCRIPTION
This PR introduces the following updates to **pyproject.toml**:

- Return previous behavior of getting version from `__init__.py` for build to avoid duplication and inconsistency
- Convert "dev" project optional dependencies (extras) to dependency group ([PEP 735](https://peps.python.org/pep-0735/)) since dev dependencies are not extras intended for installation by user